### PR TITLE
Do not export empty strings

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,4 @@
 files:
   - source: /en.json
     translation: /%locale%.json
+    skip_untranslated_strings: true


### PR DESCRIPTION
Per Crowdin documentation, having this should stop Crowdin from exporting strings that are [not translated](https://github.com/modrinth/translations/pull/17/commits/c7f3c569faeab057108cb9553170e95485419344#diff-7117c28877cb31c4ecd033782f0228b5b46dc28fd5883a81e49c3214ccb47041R3), thus it will be creating partial JSON. If I read correctly, [correctly set up](https://svelte-intl-precompile.com/en/docs/configuration#:~:text=/script%3E-,Default%20%26%20fallback%20locales,-To%20the%20call) `svelte-intl-precompile` handles that and will fall back to English.