### PR TITLE
Do not skip untranslated strings

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,4 +1,3 @@
 files:
   - source: /en.json
     translation: /%locale%.json
-    skip_untranslated_strings: true


### PR DESCRIPTION
In PR #18 I have tried to make it so Crowdin does not export untranslated strings, thinking Crowdin won't export them at all.
However, what I did not know at time is that `svelte-intl-precompiled` `fallbackLocale` actually does not actually do anything besides serving as a fallback option when none of locales in the `Accept-Languages` header exist. Neither did I know is that Crowdin's `skip_untranslated_strings` does not properly work with nested JSON [^1], which Modrinth translation files are. Instead, Crowdin exports empty strings, which is worse than exporting no strings at all, since `svelte-intl-precompiled` considers empty strings translated, which for incomplete languages makes parts of UI show blank space.

I'm not sure if this will work either, but we'll never know unless we try. As their documentation says, by default they should use source strings to pre-fill untranslated ones, if that's so, that's probably the desired behaviour with `svelte-intl-precompiled` :shrug:

If this won't work, we'll have to resort to exporting only fully translated languages, which is terrible for small languages who have
only so few translators. On top of that, having even partial translations encourages people to see if they can contribute (though I believe in the future there should be a message on how to do that, like in Mastodon [^2]).

[^1]: https://support.crowdin.com/advanced-project-setup/#export
[^2]: ![Screenshot of Mastodon showing a note in foreign language that ‘Mastodon is translated by volunteers. Everyone can contribute.’](https://user-images.githubusercontent.com/10401817/171769617-2da6ee51-63f0-4d67-b97a-473f4a5043ce.png)